### PR TITLE
refactor: improve background design and login card style

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,17 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap");
+
+body {
+  font-family: "Poppins", sans-serif;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
 @keyframes orbPulse {
   0% {
     transform: scale(1);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "./globals.css";
 import React from "react";
 import {
   ApolloProvider,

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, FormEvent } from "react";
 import { motion } from "framer-motion";
 import { Card, CardContent, Typography, TextField, Button, Box } from "@mui/material";
+import AnimatedBackground from "@/components/AnimatedBackground";
 
 export default function LoginPage() {
   const [identifier, setIdentifier] = useState("");
@@ -40,22 +41,13 @@ export default function LoginPage() {
   };
 
   return (
-    <motion.div
-      initial={{ backgroundPosition: "0% 50%" }}
-      animate={{ backgroundPosition: ["0% 50%", "100% 50%", "0% 50%"] }}
-      transition={{ duration: 10, repeat: Infinity }}
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        backgroundImage: "linear-gradient(120deg, #ffafbd, #ffc3a0, #2193b0, #6dd5ed)",
-        backgroundSize: "200% 200%",
-      }}
+    <AnimatedBackground
+      style={{ display: "flex", justifyContent: "center", alignItems: "center" }}
     >
       <Box sx={{ display: "flex", justifyContent: "center", width: "100%", padding: 2 }}>
         <Card
           component={motion.div}
+          className="glass-card"
           initial={{ scale: 0.8, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ type: "spring", stiffness: 100, damping: 10 }}
@@ -103,6 +95,6 @@ export default function LoginPage() {
           </CardContent>
         </Card>
       </Box>
-    </motion.div>
+    </AnimatedBackground>
   );
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { motion } from "framer-motion";
+import AnimatedBackground from "@/components/AnimatedBackground";
 import CrazyAuditsTable from "@/components/AuditsTable";
 import CrazyAuditStats from "@/components/CrazyAudit";
 import RankDisplay from "@/components/LevelProgressChart";
@@ -19,19 +19,12 @@ const ProfilePage = () => {
   };
 
   return (
-    <motion.div
-      initial={{ backgroundPosition: "0% 50%" }}
-      animate={{ backgroundPosition: ["0% 50%", "100% 50%", "0% 50%"] }}
-      transition={{ duration: 10, repeat: Infinity }}
+    <AnimatedBackground
       style={{
-        minHeight: "100vh",
         display: "flex",
         flexDirection: "column",
-        backgroundImage: "linear-gradient(120deg, #ffafbd, #ffc3a0, #2193b0, #6dd5ed)",
-        backgroundSize: "200% 200%",
         padding: "20px",
         color: "#fff",
-        fontFamily: "'Poppins', sans-serif",
       }}
     >
       {/* Logout Button */}
@@ -107,7 +100,7 @@ const ProfilePage = () => {
       <div>
         <CrazyProjectCards />
       </div>
-    </motion.div>
+    </AnimatedBackground>
   );
 };
 

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { motion, HTMLMotionProps } from "framer-motion";
+
+type AnimatedBackgroundProps = HTMLMotionProps<"div"> & {
+  children: React.ReactNode;
+};
+
+const AnimatedBackground: React.FC<AnimatedBackgroundProps> = ({
+  children,
+  style,
+  ...rest
+}) => (
+  <motion.div
+    initial={{ backgroundPosition: "0% 50%" }}
+    animate={{ backgroundPosition: ["0% 50%", "100% 50%", "0% 50%"] }}
+    transition={{ duration: 10, repeat: Infinity }}
+    style={{
+      minHeight: "100vh",
+      backgroundImage:
+        "linear-gradient(120deg, #ffafbd, #ffc3a0, #2193b0, #6dd5ed)",
+      backgroundSize: "200% 200%",
+      ...style,
+    }}
+    {...rest}
+  >
+    {children}
+  </motion.div>
+);
+
+export default AnimatedBackground;


### PR DESCRIPTION
## Summary
- add reusable `AnimatedBackground` component for shared gradient animation
- apply global Poppins font and glass-card styling for polished UI
- update login and profile pages to use the animated background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1cd73f858832da8b88a257f2e1e1a